### PR TITLE
Fix command title of eraseTypeAnnotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "commands": [
             {
                 "command": "extension.eraseTypeAnnotations",
-                "title": "Erase Stainless Fit Type Annotations"
+                "title": "Stainless Fit: Erase Type Annotations"
             }
         ],
         "keybindings": [


### PR DESCRIPTION
Updated to align with other extensions, placing the name of the language before the command